### PR TITLE
Updating Dockerfile to fit best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,36 @@
 FROM quay.io/ukhomeofficedigital/centos-base
 
-ENV RUBY_VERSION 2.3.0
+ENV RUBY_VERSION 2.3.3
 
-RUN yum clean all && \
-    yum update -y && \
-# Install all packages required by RVM
-    yum install -y which patch libyaml-devel \
-    glibc-headers autoconf gcc-c++ glibc-devel \
-    patch readline-devel zlib-devel libffi-devel \
-    openssl-devel make bzip2 automake libtool \
-    bison sqlite-devel && \
-    yum clean all && \
-    rpm --rebuilddb
+# Onbuild commands ensure packages are updated whenever an image is built on top of this one
+ONBUILD RUN yum clean all && \
+            yum update -y && \
+            yum install -y git && \
+            yum clean all && \
+            rpm --rebuilddb
+ONBUILD ADD Gemfile /app
+ONBUILD RUN bundle install
+ONBUILD ADD . /app
 
-#Install RVM with latest stable ruby and bundle
-RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -  && \
-    /usr/bin/curl -L https://get.rvm.io | /bin/bash -s stable --ruby \
-    --with-default-gems="bundle"
+RUN yum install -y wget make bzip2 gcc-c++
+
+#   Install Ruby
+RUN \
+#   Get GPG key
+    wget https://raw.github.com/postmodern/postmodern.github.io/master/postmodern.asc && \
+    gpg --import postmodern.asc && \
+    wget https://raw.github.com/postmodern/ruby-install/master/pkg/ruby-install-0.6.0.tar.gz.asc && \
+#   Download ruby-install and verify against the GPG key
+    wget -O ruby-install-0.6.0.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.0.tar.gz && \
+    gpg --verify ruby-install-0.6.0.tar.gz.asc ruby-install-0.6.0.tar.gz && \
+    tar -xzvf ruby-install-0.6.0.tar.gz && cd ruby-install-0.6.0 && make install && \
+#    Install Ruby
+    ruby-install --system ruby 2.2.6 && gem install bundler
 
 #Create app user and group
 RUN groupadd -r app && \
     useradd -r -g app app -d /app && \
     mkdir -p /app && \
     chown -R app:app /app
-
-ENV GEM_PATH=/usr/local/rvm/gems/ruby-${RUBY_VERSION}:/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global \
-    RUBY_VERSION=ruby-${RUBY_VERSION} \
-    GEM_HOME=/usr/local/rvm/gems/ruby-${RUBY_VERSION} \
-    PATH=${PATH}:/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/bin:/usr/local/rvm/gems/ruby-${RUBY_VERSION}/bin:/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global/bin
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ This is a base container for projects that require ruby.
 
 ## Usage  
 
-Put `FROM quay.io/ukhomeofficedigital/ruby` in the top of your Dockerfile
+Example:
+```
+FROM quay.io/ukhomeofficedigital/ruby
+USER app
+``` 
+
+This is an onbuild image and will automatically install copy your app to /app and install it's dependencies with bundler, 
+as well as updating OS packages. It has a pre-setup user called app to ensure your app doesn't run as root.
 
 ### Useful Directories
 
@@ -29,6 +36,7 @@ We use [SemVer](http://semver.org/) for the version tags available See the tags 
 ## Authors
 
 * **Jay Keshur** - *Initial work* - [jaykeshur](https://github.com/jaykeshur)
+* **Tim Gent** - *Updates* - [timgent](https://github.com/timgent)
 
 See also the list of
 [contributors](https://github.com/UKHomeOffice/docker-ruby/graphs/contributors) who participated


### PR DESCRIPTION
- Use ruby-installer as it is a little lighter weight than rvm (no point in rvm as people shouldn't be changing ruby versions within their app)
- Has onbuild commands for running yum commands
- Has onbuild commands for copying app to /app and
- Explicitly says in readme to use the app user that is created
- Updated to use latest stable ruby version